### PR TITLE
Add Checker

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,6 @@ options:
   poll_time_seconds: 60
   timeout_seconds: 5
 services:
-  name: third-rail
-  endpoint: third-rail.services.smartatransit.com/health
-  enabled: true
+  -  name: third-rail
+     endpoint: https://third-rail-insecure.services.smartatransit.com/health
+     enabled: true

--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -27,8 +27,7 @@ func (c CheckClient) runChecks(ctx context.Context) {
 		b, err := check.Check(ctx)
 		if err != nil {
 			c.logger.Error(err.Error())
-		}
-		if !b {
+		} else if !b {
 			c.logger.Error(check.ErrorMessage())
 		}
 	}

--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -2,8 +2,6 @@ package health
 
 import (
 	"context"
-	"fmt"
-	"net/http"
 	"time"
 
 	"go.uber.org/zap"
@@ -22,29 +20,6 @@ type Check interface {
 
 func NewCheckClient(c Config, logger *zap.Logger) *CheckClient {
 	return &CheckClient{config: c, logger: logger}
-}
-
-type EndpointCheck struct {
-	endpoint string
-	enabled  bool
-	name     string
-	err      string
-}
-
-func (e *EndpointCheck) Check(ctx context.Context) (bool, error) {
-	resp, err := http.Get(e.endpoint)
-	if err != nil {
-		return false, err
-	}
-	if resp.Status == "200" {
-		return true, err
-	}
-	e.err = fmt.Sprintf("Service %s returned status code %s at endpoint %s", e.name, resp.Status, e.endpoint)
-	return false, err
-}
-
-func (e *EndpointCheck) ErrorMessage() string {
-	return e.err
 }
 
 func (c CheckClient) runChecks(ctx context.Context) {

--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -1,0 +1,85 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type CheckClient struct {
+	config Config
+	checks []Check
+	logger *zap.Logger
+}
+
+type Check interface {
+	Check(context.Context) (bool, error)
+	ErrorMessage() string
+}
+
+func NewCheckClient(c Config, logger *zap.Logger) *CheckClient {
+	return &CheckClient{config: c, logger: logger}
+}
+
+type EndpointCheck struct {
+	endpoint string
+	enabled  bool
+	name     string
+	err      string
+}
+
+func (e *EndpointCheck) Check(ctx context.Context) (bool, error) {
+	resp, err := http.Get(e.endpoint)
+	if err != nil {
+		return false, err
+	}
+	if resp.Status == "200" {
+		return true, err
+	}
+	e.err = fmt.Sprintf("Service %s returned status code %s at endpoint %s", e.name, resp.Status, e.endpoint)
+	return false, err
+}
+
+func (e *EndpointCheck) ErrorMessage() string {
+	return e.err
+}
+
+func (c CheckClient) runChecks(ctx context.Context) {
+	for _, check := range c.checks {
+		b, err := check.Check(ctx)
+		if err != nil {
+			c.logger.Error(err.Error())
+		}
+		if !b {
+			c.logger.Error(check.ErrorMessage())
+		}
+	}
+}
+
+func (c CheckClient) buildChecks() []Check {
+	var checks []Check
+	for _, service := range c.config.Services {
+		checks = append(checks, &EndpointCheck{service.Endpoint, service.Enabled, service.Name, ""})
+	}
+	return checks
+}
+
+func (c *CheckClient) Start(ctx context.Context) {
+	c.checks = c.buildChecks()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				c.logger.Info("exiting poll")
+				return
+			default:
+			}
+
+			c.runChecks(ctx)
+			time.Sleep(time.Duration(c.config.Options.PollTimeSeconds) * time.Second)
+		}
+	}()
+}

--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -16,6 +16,7 @@ type CheckClient struct {
 type Check interface {
 	Check(context.Context) (bool, error)
 	ErrorMessage() string
+	Enabled() bool
 }
 
 func NewCheckClient(c Config, logger *zap.Logger) *CheckClient {
@@ -24,11 +25,13 @@ func NewCheckClient(c Config, logger *zap.Logger) *CheckClient {
 
 func (c CheckClient) runChecks(ctx context.Context) {
 	for _, check := range c.checks {
-		b, err := check.Check(ctx)
-		if err != nil {
-			c.logger.Error(err.Error())
-		} else if !b {
-			c.logger.Error(check.ErrorMessage())
+		if check.Enabled() {
+			b, err := check.Check(ctx)
+			if err != nil {
+				c.logger.Error(err.Error())
+			} else if !b {
+				c.logger.Error(check.ErrorMessage())
+			}
 		}
 	}
 }

--- a/pkg/health/config.go
+++ b/pkg/health/config.go
@@ -1,4 +1,4 @@
-package config
+package health
 
 import (
 	"os"
@@ -12,7 +12,7 @@ type Config struct {
 		PollTimeSeconds int `yaml:"poll_time_seconds"`
 		TimeoutSeconds  int `yaml:"timeout_seconds"`
 	} `yaml:"options"`
-	Services struct {
+	Services []struct {
 		Name     string `yaml:"name"`
 		Endpoint string `yaml:"endpoint"`
 		Enabled  bool   `yaml:"enabled"`

--- a/pkg/health/endpoint.go
+++ b/pkg/health/endpoint.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type Response struct {
-	Service  string      `json:"service"`
-	Name     string      `json:"name"`
-	Metadata interface{} `json:"metadata"`
+	Statuses []struct {
+		Service  string      `json:"service"`
+		Name     string      `json:"name"`
+		Metadata interface{} `json:"metadata"`
+	} `json:"statuses"`
 }
 
 type EndpointCheck struct {
@@ -21,21 +24,34 @@ type EndpointCheck struct {
 	err      string
 }
 
+func (e *EndpointCheck) validateResp(resp Response) bool {
+	if len(resp.Statuses) == 0 {
+		return true
+	}
+	var str strings.Builder
+	str.WriteString(fmt.Sprintf("Service %s has reported the following subservices are in a degraded state: ", e.name))
+	for _, status := range resp.Statuses {
+		str.WriteString(fmt.Sprintf("Service %s, Name %s, Metadata %v;", status.Service, status.Name, status.Metadata))
+	}
+	e.err = str.String()
+	return false
+}
+
 func (e *EndpointCheck) Check(ctx context.Context) (bool, error) {
 	r, err := http.Get(e.endpoint)
 	if err != nil {
 		return false, err
 	}
-	if r.Status == "200" {
+	if r.StatusCode == 200 {
 		resp := Response{}
-		derr := json.NewDecoder(r.Body).Decode(resp)
+		derr := json.NewDecoder(r.Body).Decode(&resp)
 		switch {
 		case derr == io.EOF:
 			return true, nil
 		case derr != nil:
 			return false, derr
 		}
-		return true, err
+		return e.validateResp(resp), err
 	}
 	e.err = fmt.Sprintf("Service %s returned status code %s at endpoint %s", e.name, r.Status, e.endpoint)
 	return false, err

--- a/pkg/health/endpoint.go
+++ b/pkg/health/endpoint.go
@@ -14,6 +14,7 @@ type Response struct {
 		Service  string      `json:"service"`
 		Name     string      `json:"name"`
 		Metadata interface{} `json:"metadata"`
+		Healthy  bool        `json:"healthy"`
 	} `json:"statuses"`
 }
 
@@ -31,7 +32,9 @@ func (e *EndpointCheck) validateResp(resp Response) bool {
 	var str strings.Builder
 	str.WriteString(fmt.Sprintf("Service %s has reported the following subservices are in a degraded state: ", e.name))
 	for _, status := range resp.Statuses {
-		str.WriteString(fmt.Sprintf("Service %s, Name %s, Metadata %v;", status.Service, status.Name, status.Metadata))
+		if !status.Healthy {
+			str.WriteString(fmt.Sprintf("Service %s, Name %s, Metadata %v;", status.Service, status.Name, status.Metadata))
+		}
 	}
 	e.err = str.String()
 	return false

--- a/pkg/health/endpoint.go
+++ b/pkg/health/endpoint.go
@@ -63,3 +63,7 @@ func (e *EndpointCheck) Check(ctx context.Context) (bool, error) {
 func (e *EndpointCheck) ErrorMessage() string {
 	return e.err
 }
+
+func (e *EndpointCheck) Enabled() bool {
+	return e.enabled
+}

--- a/pkg/health/endpoint.go
+++ b/pkg/health/endpoint.go
@@ -1,0 +1,46 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type Response struct {
+	Service  string      `json:"service"`
+	Name     string      `json:"name"`
+	Metadata interface{} `json:"metadata"`
+}
+
+type EndpointCheck struct {
+	endpoint string
+	enabled  bool
+	name     string
+	err      string
+}
+
+func (e *EndpointCheck) Check(ctx context.Context) (bool, error) {
+	r, err := http.Get(e.endpoint)
+	if err != nil {
+		return false, err
+	}
+	if r.Status == "200" {
+		resp := Response{}
+		derr := json.NewDecoder(r.Body).Decode(resp)
+		switch {
+		case derr == io.EOF:
+			return true, nil
+		case derr != nil:
+			return false, derr
+		}
+		return true, err
+	}
+	e.err = fmt.Sprintf("Service %s returned status code %s at endpoint %s", e.name, r.Status, e.endpoint)
+	return false, err
+}
+
+func (e *EndpointCheck) ErrorMessage() string {
+	return e.err
+}


### PR DESCRIPTION
This PR allows us to handle healthcheck responses.

When given a `200` status code with a request body like:
```json
{
  "statuses": [
    {
      "name": "test",
      "metadata": {
        "test": 1
      },
      "service": "test"
    }
  ]
}
```
we'd log to stdout:
```json
{
  "level": "error",
  "ts": 1597695041.0568478,
  "caller": "health/check.go:31",
  "msg": "Service third-rail has reported the following subservices are in a degraded state: Service test, Name test, Metadata map[test:1];",
  "stacktrace": "github.com/smartatransit/healthcheck/pkg/health.CheckClient.runChecks\n\t/Users/bipol/Repos/healthcheck/pkg/health/check.go:31\ngithub.com/smartatransit/healthcheck/pkg/health.(*CheckClient).Start.func1\n\t/Users/bipol/Repos/healthcheck/pkg/health/check.go:55"
}
```

which would be picked up by our elastalert.

Currently, we only hit endpoints, but the `Check` interface allows you to specify different ways to determine the health of something in the future.