### PR TITLE
create auth client and add feedback service to config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.14 AS builder
 WORKDIR /src
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY config.yaml config.yaml
 COPY main.go main.go
 COPY pkg/ pkg/
 COPY vendor/ vendor/

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,6 @@ options:
   poll_time_seconds: 60
   timeout_seconds: 5
 services:
-  -  name: third-rail
-     endpoint: https://third-rail-insecure.services.smartatransit.com/health
+  -  name: feedback
+     endpoint: https://feedback.services.smartatransit.com/v1/health
      enabled: true

--- a/pkg/auth/client.go
+++ b/pkg/auth/client.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+type TokenResponse struct {
+	Token string `json:"token"`
+}
+
+type Client struct {
+	http   *http.Client
+	logger *zap.Logger
+}
+
+func NewClient(http *http.Client, logger *zap.Logger) *Client {
+	return &Client{
+		http,
+		logger,
+	}
+}
+
+func (c Client) Get(url string) (*http.Response, error) {
+	var tokenResp TokenResponse
+	r, err := c.http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	if r.StatusCode == 200 {
+		return r, err
+	} else if r.StatusCode == 401 {
+		derr := json.NewDecoder(r.Body).Decode(&tokenResp)
+		switch {
+		case derr == io.EOF:
+			return nil, errors.New("no token was given")
+		case derr != nil:
+			return nil, derr
+		}
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tokenResp.Token))
+	resp, err := c.http.Do(req)
+	return resp, err
+}

--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -2,8 +2,10 @@ package health
 
 import (
 	"context"
+	"net/http"
 	"time"
 
+	"github.com/smartatransit/healthcheck/pkg/auth"
 	"go.uber.org/zap"
 )
 
@@ -37,9 +39,10 @@ func (c CheckClient) runChecks(ctx context.Context) {
 }
 
 func (c CheckClient) buildChecks() []Check {
+	client := auth.NewClient(&http.Client{}, c.logger)
 	var checks []Check
 	for _, service := range c.config.Services {
-		checks = append(checks, &EndpointCheck{service.Endpoint, service.Enabled, service.Name, ""})
+		checks = append(checks, &EndpointCheck{service.Endpoint, service.Enabled, service.Name, "", client})
 	}
 	return checks
 }


### PR DESCRIPTION
I wasn't handling the JWT authentication requirement that the feedback service is behind, so this implements a client that can handle that for us.